### PR TITLE
Allow preserving of original file name rather than forcing jspm-bundle.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ module.exports = function(opts){
 
         var enable_source_map = !!file.sourceMap;
 
+        var originalFileName = path.basename(file.path);
+
         var push = this.push.bind(this);
 
         Promise.resolve()
@@ -85,7 +87,7 @@ module.exports = function(opts){
             var bundle_file =
                 new File({
                     base: file.base,
-                    path: path.join(path.dirname(file.path), 'jspm-bundle.js'),
+                    path: path.join(path.dirname(file.path), (opts.preserveFileName?originalFileName:'jspm-bundle.js')),
                     contents: results.contents
                 });
 


### PR DESCRIPTION
This allows for a build pipeline that can process multiple modules
```
gulp.task('build-jspm', function () {
  gulp.src('src/*.js')
    .pipe(sourcemaps.init())
    .pipe(jspm({preserveFileName: true}))
    .pipe(sourcemaps.write('.'))
    .pipe(gulp.dest('dist'));
})
```

This allows `src/some_app.js` and `src/other_app.js` to be bundled seperately to produce a `dist/some_app.js` and `dist/other_app.js`, each bundled only with their own dependencies.