### PR TITLE
Upgrade to use jspm 0.17.0-beta.22

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var File = require('vinyl');
 var fs = Promise.promisifyAll(require("fs"));
 var path = require('path');
 var projectName = require('./package.json').name;
-
+var Builder = require('jspm').Builder;
+var builder = new Builder();
 
 jspm.on('log', function(type, msg) {
     var logTypes = ['err', 'warn', 'ok', 'info', 'debug'];
@@ -116,6 +117,7 @@ function do_bundle(file, opts){
                 if( opts.arithmetic ) {
                     jspm_input += ' ' + opts.arithmetic.trim();
                 }
+                jspm_input = jspm_input.replace(/\\/g, '/');
                 return jspm_input;
         })();
 
@@ -132,13 +134,11 @@ function do_bundle(file, opts){
                     return jspm_opts;
         })();
 
-        var method = opts.selfExecutingBundle?'bundleSFX':'bundle';
-
+        var method = opts.selfExecutingBundle?'buildStatic':'bundle';
+        
         info_log('calling `jspm.'+method+"('"+jspm_input+"','"+jspm_output+"',"+JSON.stringify(jspm_opts)+');`', infos);
 
-        return Promise.resolve(
-            jspm[method](jspm_input, jspm_output, jspm_opts)
-        )
+        return builder[method](jspm_input, jspm_output, jspm_opts)
         .then(function(){
             info_log('jspm.'+method+'() called', infos);
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "gulp-jspm",
-  "version": "0.5.11",
+  "version": "0.6.0-beta.0",
   "description": "gulp plugin to build assets loaded with jspm/SystemJS",
   "main": "index.js",
   "dependencies": {
     "bluebird": "^3.3.5",
     "gulp-util": "^3.0.7",
-    "jspm": "^0.16.34",
+    "jspm": "^0.17.0-beta.22",
     "liftoff": "^2.2.1",
     "mini-assert": "^1.0.7",
     "temp": "^0.8.3",


### PR DESCRIPTION
This was the minimum number of changes I needed to make to get gulp-jspm working with the beta. Which was mentioned in #25.  More work may still need to be done but it's a start. Thoughts?