### PR TITLE
Add support for separateCSS (and similar features)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 jspm_packages/
 demo/build/
+*.iml

--- a/index.js
+++ b/index.js
@@ -117,7 +117,13 @@ function do_bundle(file, opts){
                 if( opts.arithmetic ) {
                     jspm_input += ' ' + opts.arithmetic.trim();
                 }
-                jspm_input = jspm_input.replace(/\\/g, '/');
+
+                // SystemJS expects modules written as urls with / instead on \
+                // \ is a valid filename on unix so only do this for windows
+                if (path.sep === '\\') {
+                  jspm_input = jspm_input.replace(/\\/g, '/');
+                }
+
                 return jspm_input;
         })();
 
@@ -135,10 +141,10 @@ function do_bundle(file, opts){
         })();
 
         var method = opts.selfExecutingBundle?'buildStatic':'bundle';
-        
+
         info_log('calling `jspm.'+method+"('"+jspm_input+"','"+jspm_output+"',"+JSON.stringify(jspm_opts)+');`', infos);
 
-        return builder[method](jspm_input, jspm_output, jspm_opts)
+        return Promise.resolve(builder[method](jspm_input, jspm_output, jspm_opts))
         .then(function(){
             info_log('jspm.'+method+'() called', infos);
 

--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ var File = require('vinyl');
 var fs = Promise.promisifyAll(require("fs"));
 var path = require('path');
 var projectName = require('./package.json').name;
-
+var Builder = require('jspm').Builder;
+var builder = new Builder();
 
 jspm.on('log', function(type, msg) {
     var logTypes = ['err', 'warn', 'ok', 'info', 'debug'];
@@ -116,6 +117,7 @@ function do_bundle(file, opts){
                 if( opts.arithmetic ) {
                     jspm_input += ' ' + opts.arithmetic.trim();
                 }
+                jspm_input = jspm_input.replace(/\\/g, '/');
                 return jspm_input;
         })();
 
@@ -132,13 +134,11 @@ function do_bundle(file, opts){
                     return jspm_opts;
         })();
 
-        var method = opts.selfExecutingBundle?'bundleSFX':'bundle';
-
+        var method = opts.selfExecutingBundle?'buildStatic':'bundle';
+        
         info_log('calling `jspm.'+method+"('"+jspm_input+"','"+jspm_output+"',"+JSON.stringify(jspm_opts)+');`', infos);
 
-        return Promise.resolve(
-            jspm[method](jspm_input, jspm_output, jspm_opts)
-        )
+        return builder[method](jspm_input, jspm_output, jspm_opts)
         .then(function(){
             info_log('jspm.'+method+'() called', infos);
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var jspm = require('jspm');
 var Liftoff = require('liftoff');
 var through = require('through2');
 var Promise = require('bluebird');
-    Promise.longStackTraces();
+Promise.longStackTraces();
 var temp = require('temp').track();
 var File = require('vinyl');
 var fs = Promise.promisifyAll(require("fs"));
@@ -12,25 +12,25 @@ var projectName = require('./package.json').name;
 var Builder = require('jspm').Builder;
 var builder = new Builder();
 
-jspm.on('log', function(type, msg) {
+jspm.on('log', function (type, msg) {
     var logTypes = ['err', 'warn', 'ok', 'info', 'debug'];
-    if( logTypes.slice(0,2).indexOf(type) !== -1 ) {
-        console.error(projectName+':', msg);
+    if (logTypes.slice(0, 2).indexOf(type) !== -1) {
+        console.error(projectName + ':', msg);
         return;
     }
     info_log(msg);
 });
 
-module.exports = function(opts){
+module.exports = function (opts) {
 
-    return through.obj(function(file, enc, cb){
+    return through.obj(function (file, enc, cb) {
 
-        if( file.isNull() ){
+        if (file.isNull()) {
             cb();
             return;
         }
 
-        if( file.isStream() ){
+        if (file.isStream()) {
             this.emit('error', new gutil.PluginError(projectName, 'Streams are not supported.'));
             cb();
             return;
@@ -40,26 +40,26 @@ module.exports = function(opts){
         var push = this.push.bind(this);
         opts = opts || {};
         do_bundle(file, opts)
-        .then(function(infos){
-            // 0ms Timeout in order to stop Promise to catch errors
-            setTimeout(function(){
-                push(infos.bundle.vinyl_file);
-                cb();
-            },0);
-        })
-        .catch(function(error) {
-            setTimeout(function() {
-                self.emit('error', new gutil.PluginError(projectName, error));
-                cb();
-            }, 0);
-        });
+            .then(function (infos) {
+                // 0ms Timeout in order to stop Promise to catch errors
+                setTimeout(function () {
+                    infos.bundle.vinyl.forEach(push);
+                    cb();
+                }, 0);
+            })
+            .catch(function (error) {
+                setTimeout(function () {
+                    self.emit('error', new gutil.PluginError(projectName, error));
+                    cb();
+                }, 0);
+            });
 
     });
 
 };
 
 
-function do_bundle(file, opts){
+function do_bundle(file, opts) {
 
     info_log.enable = !!opts.verbose;
 
@@ -70,156 +70,165 @@ function do_bundle(file, opts){
                 package_path: null
             },
             bundle: {
+                dir: null,
                 path: null,
-                contents: null,
-                sourceMap: null,
-                vinyl_file: null
+                files: {},
+                sourceMaps: {},
+                vinyl: []
             }
         }
     )
-    .then(function(infos){
-        info_log('start', infos);
+        .then(function (infos) {
+            info_log('start', infos);
 
-        return (
-            get_paths(file.base)
-        ).then(function(paths){
-            jspm.setPackagePath(paths.package_path);
+            return (
+                get_paths(file.base)
+            ).then(function (paths) {
+                jspm.setPackagePath(paths.package_path);
 
-            infos.jspm.package_path = paths.package_path;
-            infos.jspm.baseURL = paths.baseURL;
+                infos.jspm.package_path = paths.package_path;
+                infos.jspm.baseURL = paths.baseURL;
 
-            info_log('relevant paths retrieved', infos);
+                info_log('relevant paths retrieved', infos);
 
-            return infos;
-        });
-    })
-    .then(function(infos){
-        return (
-            Promise.promisify(temp.open)('gulp-jspm__build.js')
-        )
-        .then(function(temp_file){
-            infos.bundle.path = temp_file.path;
+                return infos;
+            });
+        })
+        .then(function (infos) {
+            return Promise.promisify(temp.mkdir)('gulp-jspm_build')
+                .then(function (temp_file) {
+                    infos.bundle.dir = temp_file;
 
-            info_log('temporary file created', infos);
+                    var basename = path.basename(file.path);
+                    basename = basename.split('.');
+                    basename.splice(1, 0, 'bundle');
+                    basename = basename.join('.');
 
-            return infos;
-        });
-    })
-    .then(function(infos){
-        var jspm_input = (function(){
+                    infos.bundle.path = path.join(temp_file, basename);
+
+                    info_log('temporary file created', infos);
+
+                    return infos;
+                });
+        })
+        .then(function (infos) {
+            var jspm_input = (function () {
                 var jspm_input = path.relative(infos.jspm.baseURL, file.path);
-                if( opts.plugin ) {
+                if (opts.plugin) {
                     jspm_input += '!';
-                    if( opts.plugin.constructor === String ) {
+                    if (opts.plugin.constructor === String) {
                         jspm_input += opts.plugin;
                     }
                 }
-                if( opts.arithmetic ) {
+                if (opts.arithmetic) {
                     jspm_input += ' ' + opts.arithmetic.trim();
                 }
 
                 // SystemJS expects modules written as urls with / instead on \
                 // \ is a valid filename on unix so only do this for windows
                 if (path.sep === '\\') {
-                  jspm_input = jspm_input.replace(/\\/g, '/');
+                    jspm_input = jspm_input.replace(/\\/g, '/');
                 }
 
                 return jspm_input;
-        })();
+            })();
 
-        var jspm_output = infos.bundle.path;
+            var jspm_output = infos.bundle.path;
 
-        var jspm_opts = (function(){
-                    var jspm_opts = {};
-                    for(var i in opts) jspm_opts[i] = opts[i];
-                    jspm_opts.sourceMaps = jspm_opts.sourceMaps || file.sourceMap;
-                    delete jspm_opts.plugin;
-                    delete jspm_opts.arithmetic;
-                    delete jspm_opts.selfExecutingBundle;
-                    delete jspm_opts.verbose;
-                    return jspm_opts;
-        })();
-
-        var method = opts.selfExecutingBundle?'buildStatic':'bundle';
-
-        info_log('calling `jspm.'+method+"('"+jspm_input+"','"+jspm_output+"',"+JSON.stringify(jspm_opts)+');`', infos);
-
-        return Promise.resolve(builder[method](jspm_input, jspm_output, jspm_opts))
-        .then(function(){
-            info_log('jspm.'+method+'() called', infos);
-
-            return infos;
-        });
-    })
-    .then(function(infos){
-        return Promise.all(
-            [
-                fs.readFileAsync(infos.bundle.path)
-                .then(function(file_content){
-                    if( file.sourceMap ) {
-                        var reSourceMapComment = /\n\/\/# sourceMappingURL=.+?$/;
-                        infos.bundle.contents = new Buffer(file_content.toString().replace(reSourceMapComment,''));
+            var jspm_opts = (function () {
+                var jspm_opts = {};
+                for (var i in opts) {
+                    if (opts.hasOwnProperty(i)) {
+                        jspm_opts[i] = opts[i];
                     }
-                    else {
-                        infos.bundle.contents = file_content;
+                }
+                jspm_opts.sourceMaps = jspm_opts.sourceMaps || file.sourceMap;
+                delete jspm_opts.plugin;
+                delete jspm_opts.arithmetic;
+                delete jspm_opts.selfExecutingBundle;
+                delete jspm_opts.verbose;
+                return jspm_opts;
+            })();
+
+            var method = opts.selfExecutingBundle ? 'buildStatic' : 'bundle';
+
+            info_log('calling `jspm.' + method + "('" + jspm_input + "','" + jspm_output + "'," + JSON.stringify(jspm_opts) + ');`', infos);
+
+            return Promise.resolve(builder[method](jspm_input, jspm_output, jspm_opts))
+                .then(function () {
+                    info_log('jspm.' + method + '() called', infos);
+
+                    return infos;
+                });
+        })
+        .then(function (infos) {
+            return new Promise(function (resolve, reject) {
+                fs.readdir(infos.bundle.dir, function (err, filenames) {
+                    if (err) {
+                        return reject(err);
                     }
-                })
-            ].concat(
-                ! file.sourceMap ? [] : (
-                    fs.readFileAsync(infos.bundle.path+'.map')
-                    .then(function(file_content){
-                        infos.bundle.sourceMap = JSON.parse(file_content.toString());
-                    })
-                )
-            )
-        )
-        .then(function(){
-            temp.cleanup();
 
-            info_log('bundle content and potentially sourceMap content read from temporary file(s)', infos);
+                    var promises = [];
+                    var reMap = /\.map$/;
+                    var reSourceMapComment = /\n\/(\/|\*)# sourceMappingURL=.+?$/;
 
-            return infos;
-        });
-    })
-    .then(function(infos){
-        var bundle_file = infos.bundle.vinyl_file =
-            new File({
-                base: file.base ,
-                path: (function(){
-                    var basename = path.basename(file.path);
-                    basename = basename.split('.');
-                    basename.splice(1, 0, 'bundle');
-                    basename = basename.join('.');
-                    return path.join(path.dirname(file.path), basename);
-                })() ,
-                contents: infos.bundle.contents
+                    filenames.forEach(function (filename) {
+                        promises.push(new Promise(function (resolve, reject) {
+                            fs.readFile(path.join(infos.bundle.dir, filename), function (err, file_content) {
+                                if (err) {
+                                    return reject(err);
+                                }
+
+                                if (reMap.test(filename)) {
+                                    infos.bundle.sourceMaps[filename.replace(reMap, '')] = JSON.parse(file_content.toString());
+                                } else {
+                                    infos.bundle.files[filename] = new Buffer(file_content.toString().replace(reSourceMapComment, ''));
+                                }
+
+                                return resolve();
+                            });
+                        }));
+                    });
+
+                    Promise.all(promises).then(resolve).catch(reject);
+                });
+            }).then(function () {
+                info_log('bundle content and potentially sourceMap content read from temporary file(s)', infos);
+
+                return infos;
+            }).finally(function () {
+                temp.cleanup();
+            });
+        })
+        .then(function (infos) {
+            Object.keys(infos.bundle.files).map(function (filename) {
+                var vinyl = new File({
+                    base: file.base,
+                    path: path.join(path.dirname(file.path), filename),
+                    contents: infos.bundle.files[filename]
+                });
+
+                vinyl.originalEntryPoint = file;
+
+                if (infos.bundle.sourceMaps[filename]) {
+                    vinyl.sourceMap = infos.bundle.sourceMaps[filename];
+                    vinyl.sourceMap.file = vinyl.relative;
+                    vinyl.sourceMap.sources = vinyl.sourceMap.sources.map(function (relative_to_temp) {
+                        return path.relative(file.base, path.resolve(path.dirname(infos.bundle.path), relative_to_temp));
+                    });
+                }
+
+                infos.bundle.vinyl.push(vinyl);
             });
 
-        bundle_file.originalEntryPoint = file;
+            info_log('vinyl_file for stream created', infos);
 
-        if( file.sourceMap ) {
-            bundle_file.sourceMap = infos.bundle.sourceMap;
-            bundle_file.sourceMap.file = bundle_file.relative;
-            bundle_file.sourceMap.sources =
-                bundle_file.sourceMap.sources.map(function(relative_to_temp){
-                    return (
-                        path.relative(
-                            file.base,
-                            path.resolve(
-                                path.dirname(infos.bundle.path),
-                                relative_to_temp))
-                    );
-                });
-        }
-
-        info_log('vinyl_file for stream created', infos);
-
-        return infos;
-    });
+            return infos;
+        });
 }
 
-function get_paths(directory){
-    return new Promise(function(resolve){
+function get_paths(directory) {
+    return new Promise(function (resolve) {
         new Liftoff({
             name: 'jspm',
             configName: 'package',
@@ -227,38 +236,38 @@ function get_paths(directory){
                 '.json': null
             }
         })
-        .launch({
-            cwd: directory
-        }, function(env) {
+            .launch({
+                cwd: directory
+            }, function (env) {
 
-            resolve({
-                baseURL: (function(){
-                    if( env.configBase ) {
-                        var package_info = require(env.configPath);
-                        if(
-                          package_info &&
-                          package_info.jspm &&
-                          package_info.jspm.directories &&
-                          package_info.jspm.directories.baseURL ) {
-                            var baseURL = package_info.jspm.directories.baseURL;
-                            return path.join(env.configBase, baseURL);
+                resolve({
+                    baseURL: (function () {
+                        if (env.configBase) {
+                            var package_info = require(env.configPath);
+                            if (
+                                package_info &&
+                                package_info.jspm &&
+                                package_info.jspm.directories &&
+                                package_info.jspm.directories.baseURL) {
+                                var baseURL = package_info.jspm.directories.baseURL;
+                                return path.join(env.configBase, baseURL);
+                            }
                         }
-                    }
-                    return env.configBase;
-                })(),
-                package_path: env.configBase
-            });
+                        return env.configBase;
+                    })(),
+                    package_path: env.configBase
+                });
 
-        });
+            });
     });
 }
 
 function info_log(message, infos) {
-    if( ! info_log.enable ) {
+    if (!info_log.enable) {
         return;
     }
-    console.log(projectName+':', message);
-    if( infos ) {
+    console.log(projectName + ':', message);
+    if (infos) {
         console.log('[[ collected information at this point;\n', infos, ']]');
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "gulp-jspm",
-  "version": "0.5.11",
+  "version": "0.6.0-beta.0",
   "description": "gulp plugin to build assets loaded with jspm/SystemJS",
   "main": "index.js",
   "dependencies": {
     "bluebird": "^3.3.5",
     "gulp-util": "^3.0.7",
-    "jspm": "^0.16.34",
+    "jspm": "^0.17.0-beta.22",
     "liftoff": "^2.2.1",
     "mini-assert": "^1.0.7",
     "temp": "^0.8.3",


### PR DESCRIPTION
Since some JSPM plugins have the ability to output additional files (like the jspm/systemjs "plugin-css") I updated the plugin to support this feature. The plugin works 90% regular, except that it uses a temp folder in which the output is generated. After the bundle operation is completed it scans this folder and adds all files to a "files" array. Any files that end with a ".map" extension are json decoded and added to the sourceMaps array (warning: if any regular files get created with a .map these will also be json decoded and this might fail, since it could be non json data). In the end instead of generating one vinyl output it generates a vinyl array in which all files are put combined with their sourceMaps (if applicable, (warning: if a file is defined in the sourceMaps but no matching regular file is found it is silently ignored)). This way you can use the separateCSS feature (and other file splitting features)...

This update is based on adamduren/gulp-jspm beta branch but the changes should be easily portable to the regular/current gulp-jspm if required.
